### PR TITLE
add paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Inside `src` folder, we can find `contacts.json`, a JSON file with the producer'
 
 Display that array of 5 contacts in a `<table>` and display the `picture`, `name`, and `popularity` of each contact.
 
+For now this has to happen in `App.js`. So don't create a dedicated component to render the contact list. Because later we will add a delete button to every contact and to make this work we have to 'lift up the state' - this we haven't learned yet.
+
 To import `contacts.json` in `App.js`, you can simply use:
 
 ```js


### PR DESCRIPTION
Adds a paragraph about not creating a dedicated ContactList component. Students already know how to do it but cannot lift the state up yet, thus will not be able to make the delete button work with their current knowledge.